### PR TITLE
Change the page title so it doesn't look off

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: two-torial.maimaidxprism.plus
+site_name: TWO-TORIAL
 copyright: two-torial Team
 site_description: Arcade Games Troubleshooting Guide
 site_author: two-torial Team


### PR DESCRIPTION
Seeing the page title just as "two-torial.maimaidxprism.plus" looks off, so I changed it back to just "TWO-TORIAL". If this shouldn't be done, please feel free to decline this PR.